### PR TITLE
Prevent invalid titles

### DIFF
--- a/classes/Importer.php
+++ b/classes/Importer.php
@@ -76,7 +76,7 @@ class Importer
 						'id'          => null,
 						'pid'         => \Input::get('id'),
 						'tstamp'      => time(),
-						'title'       => $config['title'],
+						'title'       => isset($config['title']) ? $config['title'] : $class,
 						'description' => $config['description'],
 						'cssclass'    => $class,
 						'layouts'     => implode(',', $layoutsWidget->value),


### PR DESCRIPTION
Title can accidently be null if the import ins combined with translated titles. Because titles are not allowed to be NULL set class as fallback
